### PR TITLE
Prevent empty Drip tags property from causing issues

### DIFF
--- a/src/destinations/drip/Drip.ts
+++ b/src/destinations/drip/Drip.ts
@@ -59,7 +59,7 @@ export default class Drip implements Destination {
       last_name: traits.lastName,
       phone: traits.phone,
       user_id: traits.id,
-      tags: traits.tags,
+      tags: traits.tags || [],
     };
 
     this.drip.push(["identify", dripUser]);


### PR DESCRIPTION
There is no obvious way to debug Drip (although we think it's probably possible to set a debug attribute somewhere), however it is throwing an error sporadically on identify (related to an undefined array). This appears to be the only array that we are potentially defining, so defaulting the property may resolve issues.