### PR TITLE
Add non-array drip products properties

### DIFF
--- a/src/destinations/drip/mapping/ecommerce/checkoutStarted.ts
+++ b/src/destinations/drip/mapping/ecommerce/checkoutStarted.ts
@@ -1,9 +1,22 @@
 import { Ecommerce } from "../../../../sourceEvents/Events";
 import { TEvent } from "../../../../types/TrackEvent";
 
+/**
+ * Checkout Started
+ *
+ * There is no standardized "Checkout Started" event with the Drip JS API, so we've created a custom one.It is similar to "Product Viewed".
+ */
 export default function checkoutStarted({
   properties,
 }: Ecommerce.CheckoutStarted): TEvent<"Checkout Started"> {
+  // Note that Drip's version of Liquid templating language doesn't seem to support arrays, so in addition to passing
+  // all products in the `products` property we we also pass properties called `product_X`. This enables you to take
+  // images etc from each product in your campaign.
+  const productsNumbered: any = {};
+  properties.products?.forEach((product, key) => {
+    productsNumbered[`product_${key + 1}`] = product;
+  });
+
   return {
     name: "Checkout Started",
     properties: {
@@ -19,6 +32,7 @@ export default function checkoutStarted({
         price: i.price ? i.price * 100 : undefined,
         ...i,
       })),
+      ...productsNumbered,
       shipping: properties.shipping,
       tax: properties.tax,
     },

--- a/src/destinations/drip/mapping/ecommerce/orderCompleted.ts
+++ b/src/destinations/drip/mapping/ecommerce/orderCompleted.ts
@@ -4,6 +4,14 @@ import { TEvent } from "../../../../types/TrackEvent";
 export default function orderCompleted({
   properties,
 }: Ecommerce.OrderCompleted): TEvent<"Order Completed"> {
+  // Note that Drip's version of Liquid templating language doesn't seem to support arrays, so in addition to passing
+  // all products in the `products` property we we also pass properties called `product_X`. This enables you to take
+  // images etc from each product in your campaign.
+  const productsNumbered: any = {};
+  properties.products?.forEach((product, key) => {
+    productsNumbered[`product_${key + 1}`] = product;
+  });
+
   return {
     name: "Order Completed",
     properties: {
@@ -19,6 +27,7 @@ export default function orderCompleted({
         price: i.price ? i.price * 100 : undefined,
         ...i,
       })),
+      ...productsNumbered,
       shipping: properties.shipping,
       tax: properties.tax,
     },

--- a/src/destinations/drip/mapping/ecommerce/tests/checkoutStarted.unit.test.ts
+++ b/src/destinations/drip/mapping/ecommerce/tests/checkoutStarted.unit.test.ts
@@ -13,6 +13,18 @@ it("creates parameters matching the snapshot", () => {
         "currency": "GBP",
         "discount": undefined,
         "order_id": "orderID",
+        "product_1": Object {
+          "category": "Trip",
+          "currency": "GBP",
+          "image_url": "http://example.com/image.jpg",
+          "name": "Product Name",
+          "price": 100,
+          "product_id": "productID",
+          "quantity": 1,
+          "sku": "sku",
+          "url": "http://example.com/productID",
+          "variant": "variant",
+        },
         "products": Array [
           Object {
             "category": "Trip",
@@ -33,4 +45,10 @@ it("creates parameters matching the snapshot", () => {
       },
     }
   `);
+});
+
+it("creates numeric product properties (e.g. product_1)", () => {
+  const res = checkoutStarted(mockCheckoutStarted);
+
+  expect(res.properties.product_1).toBeTruthy();
 });

--- a/src/destinations/drip/mapping/ecommerce/tests/orderCompleted.unit.test.ts
+++ b/src/destinations/drip/mapping/ecommerce/tests/orderCompleted.unit.test.ts
@@ -13,6 +13,18 @@ it("creates parameters matching the snapshot", () => {
         "currency": "GBP",
         "discount": undefined,
         "order_id": "orderID",
+        "product_1": Object {
+          "category": "Trip",
+          "currency": "GBP",
+          "image_url": "http://example.com/image.jpg",
+          "name": "Product Name",
+          "price": 100,
+          "product_id": "productID",
+          "quantity": 1,
+          "sku": "sku",
+          "url": "http://example.com/productID",
+          "variant": "variant",
+        },
         "products": Array [
           Object {
             "category": "Trip",

--- a/src/destinations/drip/tests/Drip.unit.test.ts
+++ b/src/destinations/drip/tests/Drip.unit.test.ts
@@ -38,7 +38,7 @@ describe("identify", () => {
 });
 
 describe("track", () => {
-  it("calls the facebook track method with parameters matching the snapshot", async () => {
+  it("calls the Drip track method with parameters matching the snapshot", async () => {
     const destination = new Drip({ accountId: "123" });
     await destination.track(mockTrack);
     expect(destination["drip"][0]).toMatchInlineSnapshot(`

--- a/src/e2e/react/src/App.tsx
+++ b/src/e2e/react/src/App.tsx
@@ -71,7 +71,7 @@ function App() {
     <div>
       <EventFanProvider
         destinations={[
-          new Drip({ accountId: "7500000" }), // Drip doesn't have a sandbox so use a dummy accountId
+          new Drip({ accountId: "7546327" }), // Drip doesn't have a sandbox so use a dummy accountId
           new FacebookPixel({ pixelId: "243635977408985" }),
           new GA4({ measurementId: "G-0PST7G69H1" }),
           new Hotjar({ siteID: "2705682" }),
@@ -79,9 +79,9 @@ function App() {
             teamApiKey: "phc_CrjkOExGDLy4CXCwuht6eEIHDM7VDNsTXAI3tpTATim",
           }),
         ]}
-        rudderStack={{
-          writeKey: "1uFnpaQiJmOxs4zG2jIon52HIhn",
-        }}
+        // rudderStack={{
+        //   writeKey: "1uFnpaQiJmOxs4zG2jIon52HIhn",
+        // }}
       >
         <Container>
           <h1>EventFan React Test</h1>


### PR DESCRIPTION
We add e.g. product_1 which is a copy of products[0], as Drip doesn't currently seem to support arrays in it's templating language.